### PR TITLE
docs: use a human-readable README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Publish Status](https://github.com/ether/ep_email_notifications/workflows/Node.js%20Package/badge.svg) [![Backend Tests Status](https://github.com/ether/ep_email_notifications/actions/workflows/test-and-release.yml/badge.svg)](https://github.com/ether/ep_email_notifications/actions/workflows/test-and-release.yml)
 
-# BROKEN PLUGIN, NEEDS FIXING
+# Email Notifications for Etherpad
 This plugin allows users to subscribe to pads and receive email updates when a pad is being modified.  You can modify the frequency.  This plugin is still in early stage and has things TODO (See TODO).
 
 # Source code


### PR DESCRIPTION
Replace the placeholder `ep_email_notifications` heading in README.md with "Email Notifications for Etherpad" so browsers of the plugin list on GitHub / npm can see what the plugin does at a glance.